### PR TITLE
Use AUTH_ACCESS_TOKEN for GH API

### DIFF
--- a/src/App/Service/Github.php
+++ b/src/App/Service/Github.php
@@ -52,7 +52,7 @@ class Github
         $this->client->addCache($pool);
 
         if (!empty($ghToken)) {
-            $this->client->authenticate($ghToken, null, Client::AUTH_URL_TOKEN);
+            $this->client->authenticate($ghToken, null, Client::AUTH_ACCESS_TOKEN);
         }
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Use AUTH_ACCESS_TOKEN for GH API instead of AUTH_URL_TOKEN
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/presthubot/issues/32
| How to test?      | Run current implementation: you should get a warning email from github. Run with this PR: no warning.
| Possible impacts? | Only authentication to GitHub API is modified

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
