### PR TITLE
Skip orphan reviews

### DIFF
--- a/src/App/Service/Transformer/GithubResultToModelTransformer.php
+++ b/src/App/Service/Transformer/GithubResultToModelTransformer.php
@@ -31,7 +31,6 @@ class GithubResultToModelTransformer
             $contributionsCollection = new ContributionsCollection();
             $contributionsCollection->setTotal($pullRequestReviewContributionByRepository['contributions']['totalCount']);
             foreach ($pullRequestReviewContributionByRepository['contributions']['nodes'] as $pullRequestReviewContribution) {
-
                 if ($pullRequestReviewContribution['pullRequestReview']['pullRequest']['author'] === null) {
                     // skip orphan reviews
                     continue;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | It seems some review data is orphan (see below). As they cannot be matched with a repository or a PR, I think we should skip them.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/presthubot/issues/30
| How to test?      | Follow ticket instructions
| Possible impacts? | No expected side effects

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

## Orphan reviews

Some review data returned by GitHub API has the following structure:
```
array(2) {
  ["occurredAt"]=>
  string(20) "2021-03-05T08:37:16Z"
  ["pullRequestReview"]=>
  array(2) {
    ["state"]=>
    string(8) "APPROVED"
    ["pullRequest"]=>
    array(1) {
      ["author"]=>
      NULL
    }
  }
}
```
