### PR TITLE
`slack:notifier` : Remove 9.0.x support

### DIFF
--- a/src/App/Command/GitHubMonthlyReportCommand.php
+++ b/src/App/Command/GitHubMonthlyReportCommand.php
@@ -36,9 +36,8 @@ class GitHubMonthlyReportCommand extends Command
     ];
 
     private const CORE_BRANCHES = [
-        '9.1.x',
         'develop',
-        '9.0.x',
+        '9.1.x',
         '8.2.x',
     ];
 

--- a/src/App/Command/SlackNotifierCommand.php
+++ b/src/App/Command/SlackNotifierCommand.php
@@ -108,7 +108,6 @@ class SlackNotifierCommand extends Command
      */
     private const BRANCH_SUPPORT = [
         '8.2.x',
-        '9.0.x',
         '9.1.x',
         'develop',
     ];
@@ -118,10 +117,7 @@ class SlackNotifierCommand extends Command
      */
     private const CAMPAIGN_SUPPORT = [
         'functional' => [
-            '8.0.x' => ['mysql'],
-            '8.1.x' => ['mysql'],
             '8.2.x' => ['mysql'],
-            '9.0.x' => ['mysql', 'mariadb'],
             '9.1.x' => ['mysql', 'mariadb'],
             'develop' => ['mysql', 'mariadb'],
         ],
@@ -130,7 +126,7 @@ class SlackNotifierCommand extends Command
         'blockwishlist' => [
             '8.0.5' => ['mysql'],
             '8.1.7' => ['mysql'],
-            '9.0.x' => ['mysql'],
+            '9.0.3' => ['mysql'],
             '9.1.x' => ['mysql'],
             'nightly' => ['mysql'],
         ],
@@ -142,7 +138,7 @@ class SlackNotifierCommand extends Command
             '8.0.5' => ['mysql'],
             '8.1.6' => ['mysql'],
             '8.2.1' => ['mysql'],
-            '9.0.x' => ['mysql'],
+            '9.0.3' => ['mysql'],
             '9.1.x' => ['mysql'],
             'nightly' => ['mysql'],
         ],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | master
| Description?      | `slack:notifier` : Remove 9.0.x support
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: 
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp