### PR TITLE
Bootstrap CI for 9.2.x

### DIFF
--- a/src/App/Command/SlackNotifierCommand.php
+++ b/src/App/Command/SlackNotifierCommand.php
@@ -109,6 +109,7 @@ class SlackNotifierCommand extends Command
     private const BRANCH_SUPPORT = [
         '8.2.x',
         '9.1.x',
+        '9.2.x',
         'develop',
     ];
 
@@ -119,6 +120,7 @@ class SlackNotifierCommand extends Command
         'functional' => [
             '8.2.x' => ['mysql'],
             '9.1.x' => ['mysql', 'mariadb'],
+            '9.2.x' => ['mysql', 'mariadb'],
             'develop' => ['mysql', 'mariadb'],
         ],
         // autoupgrade (Done in specific report)


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | master
| Description?      | Add the new version branch `9.2.x` (opened for 9.2.0) to this repository's CI matrices / branch lists.
| Type?             | improvement
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Review the diff: `9.2.x` is added wherever active version branches are enumerated.
| UI Tests          | N/A
| Fixed issue or discussion? | N/A
| Related PRs       | Companion PRs opened by the same "Version-branch bootstrap" run.
| Sponsor company   | N/A

> 🤖 Opened automatically by the **Version-branch bootstrap** workflow. Idempotent: re-running updates this PR; if it was closed, a new one is created.